### PR TITLE
Prime entities and entity types

### DIFF
--- a/app/src/main/java/pen/apis/HistoryExtension.java
+++ b/app/src/main/java/pen/apis/HistoryExtension.java
@@ -6,10 +6,7 @@ import pen.DataFiles;
 import pen.calendars.Calendar;
 import pen.calendars.CalendarException;
 import pen.calendars.formatter.DateFormat;
-import pen.history.Entity;
-import pen.history.HistoryBank;
-import pen.history.HistoryQuery;
-import pen.history.Incident;
+import pen.history.*;
 import pen.tcl.Argq;
 import pen.tcl.TclEngine;
 import pen.tcl.TclExtension;
@@ -71,6 +68,7 @@ public class HistoryExtension implements TclExtension {
         this.tcl = tcl;
 
         tcl.add("calendar", this::cmd_calendar);
+        tcl.add("type",     this::cmd_type);
         tcl.add("entity",   this::cmd_entity);
         tcl.add("start",    this::cmd_start);
         tcl.add("end",      this::cmd_end);
@@ -160,18 +158,17 @@ public class HistoryExtension implements TclExtension {
     }
 
 
-    // entity id name type
+    // type id name ?-prime?
     //
-    // Adds a new entity to the history, assigning it a unique ID, a
-    // name for display, and a type.
-    private void cmd_entity(TclEngine tcl, Argq argq)
+    // Adds a new entity type to the history, assigning it a unique ID, a
+    // name for display, and a prime flag.
+    private void cmd_type(TclEngine tcl, Argq argq)
         throws TclException
     {
-        tcl.checkArgs(argq, 3, 4, "id name type ?-prime?");
+        tcl.checkArgs(argq, 2, 3, "id name ?-prime?");
 
         var id = tcl.toIdentifier(argq.next());
         var name = argq.next().toString().trim();
-        var type = tcl.toIdentifier(argq.next());
         boolean prime;
 
         if (argq.hasNext()) {
@@ -185,7 +182,45 @@ public class HistoryExtension implements TclExtension {
             prime = false;
         }
 
-        var entity = new Entity(id, name, type, prime);
+        var type = new EntityType(id, name, prime);
+
+        if (bank.getEntityType(id).isPresent()) {
+            throw tcl.error("Duplicate entity type: \"" + type.id());
+        }
+
+        if (type.name().isEmpty()) {
+            throw tcl.expected("entity type name", type.name());
+        }
+
+        bank.addEntityType(type);
+    }
+
+    // entity id name type ?-prime?
+    //
+    // Adds a new entity to the history, assigning it a unique ID, a
+    // name for display, and a type.
+    private void cmd_entity(TclEngine tcl, Argq argq)
+        throws TclException
+    {
+        tcl.checkArgs(argq, 3, 4, "id name type ?-prime?");
+
+        var id = tcl.toIdentifier(argq.next());
+        var name = argq.next().toString().trim();
+        var type = toType(argq.next());
+        boolean prime;
+
+        if (argq.hasNext()) {
+            var opt = argq.next().toString();
+            if (opt.equals("-prime")) {
+                prime = true;
+            } else {
+                throw tcl.badValue("Unknown option", opt);
+            }
+        } else {
+            prime = false;
+        }
+
+        var entity = new Entity(id, name, type.id(), prime);
 
         if (entityLimits.get(entity.id()) != null) {
             throw tcl.error("Duplicate entity: \"" + entity.id());
@@ -193,10 +228,6 @@ public class HistoryExtension implements TclExtension {
 
         if (entity.name().isEmpty()) {
             throw tcl.expected("entity name", entity.name());
-        }
-
-        if (entity.type().isEmpty()) {
-            throw tcl.expected("entity type", entity.type());
         }
 
         entityLimits.put(entity.id(), new Limits(entity));
@@ -439,6 +470,16 @@ public class HistoryExtension implements TclExtension {
             return new DateFormat(arg.toString());
         } catch (CalendarException ex) {
             throw tcl.expected("date format", arg);
+        }
+    }
+
+    private EntityType toType(TclObject arg) throws TclException {
+        var type = bank.getEntityType(arg.toString());
+
+        if (type.isPresent()) {
+            return type.get();
+        } else {
+            throw tcl.expected("known entity type ID", arg);
         }
     }
 

--- a/app/src/main/java/pen/apis/HistoryExtension.java
+++ b/app/src/main/java/pen/apis/HistoryExtension.java
@@ -167,13 +167,25 @@ public class HistoryExtension implements TclExtension {
     private void cmd_entity(TclEngine tcl, Argq argq)
         throws TclException
     {
-        tcl.checkArgs(argq, 3, 3, "id name type");
+        tcl.checkArgs(argq, 3, 4, "id name type ?-prime?");
 
-        var entity = new Entity(
-            tcl.toIdentifier(argq.next()),
-            argq.next().toString().trim(),
-            tcl.toIdentifier(argq.next())
-        );
+        var id = tcl.toIdentifier(argq.next());
+        var name = argq.next().toString().trim();
+        var type = tcl.toIdentifier(argq.next());
+        boolean prime;
+
+        if (argq.hasNext()) {
+            var opt = argq.next().toString();
+            if (opt.equals("-prime")) {
+                prime = true;
+            } else {
+                throw tcl.badValue("Unknown option", opt);
+            }
+        } else {
+            prime = false;
+        }
+
+        var entity = new Entity(id, name, type, prime);
 
         if (entityLimits.get(entity.id()) != null) {
             throw tcl.error("Duplicate entity: \"" + entity.id());

--- a/app/src/main/java/pen/history/AbstractHistory.java
+++ b/app/src/main/java/pen/history/AbstractHistory.java
@@ -11,7 +11,10 @@ public abstract class AbstractHistory implements History {
     // The calendar information
     private Function<Integer, String> momentFormatter;
 
-    // The entities in this diagram.  Use a LinkedHashMap to preserve
+    // The entity types in this history.
+    private final SequencedMap<String,EntityType> typeMap = new LinkedHashMap<>();
+
+    // The entities in this history.  Use a LinkedHashMap to preserve
     private final SequencedMap<String, Entity> entityMap =
         new LinkedHashMap<>();
 
@@ -40,6 +43,15 @@ public abstract class AbstractHistory implements History {
     // Protected Members, for use by subclasses.
     //
     // Subclasses are free to edit and view the history as they like.
+
+    protected final SequencedMap<String, EntityType> typeMap() {
+        return typeMap;
+    }
+
+    protected final void setTypeMap(Map<String, EntityType> map) {
+        typeMap.clear();
+        typeMap.putAll(map);
+    }
 
     protected final SequencedMap<String, Entity> entityMap() {
         return entityMap;

--- a/app/src/main/java/pen/history/Entity.java
+++ b/app/src/main/java/pen/history/Entity.java
@@ -5,10 +5,12 @@ package pen.history;
  * @param id The entity's unique ID
  * @param name An entity name for display
  * @param type The entity's type, for grouping.
+ * @param prime If true, the entity is of primary importance.
  */
 public record Entity(
     String id,
     String name,
-    String type
+    String type,
+    boolean prime
 ) {
 }

--- a/app/src/main/java/pen/history/EntityType.java
+++ b/app/src/main/java/pen/history/EntityType.java
@@ -1,0 +1,13 @@
+package pen.history;
+
+/**
+ * An entity type in a history.
+ * @param id The type's ID.
+ * @param name The type's display name
+ * @param prime Whether the type is of primary importance or not.
+ */
+public record EntityType(
+    String id,
+    String name,
+    boolean prime
+) { }

--- a/app/src/main/java/pen/history/History.java
+++ b/app/src/main/java/pen/history/History.java
@@ -21,7 +21,13 @@ public interface History {
     Function<Integer,String> getMomentFormatter();
 
     /**
-     * The entities in the history, by name.
+     * The entity types in the history, by id.
+     * @return The entities.
+     */
+    Map<String, EntityType> getTypeMap();
+
+    /**
+     * The entities in the history, by id.
      * @return The entities.
      */
     Map<String, Entity> getEntityMap();

--- a/app/src/main/java/pen/history/HistoryBank.java
+++ b/app/src/main/java/pen/history/HistoryBank.java
@@ -22,6 +22,22 @@ public class HistoryBank
         setMomentFormatter(null);
     }
 
+    public Map<String,EntityType> getTypeMap() {
+        return typeMap();
+    }
+
+    public void addEntityType(EntityType type) {
+        typeMap().put(type.id(), type);
+    }
+
+    public Optional<EntityType> removeEntityType(String id) {
+        return Optional.ofNullable(typeMap().remove(id));
+    }
+
+    public Optional<EntityType> getEntityType(String id) {
+        return Optional.ofNullable(typeMap().get(id));
+    }
+
     public Map<String,Entity> getEntityMap() {
         return entityMap();
     }

--- a/app/src/main/java/pen/history/HistoryQuery.java
+++ b/app/src/main/java/pen/history/HistoryQuery.java
@@ -389,7 +389,11 @@ public class HistoryQuery {
                 }
             }
 
-            var result = new HistoryView(map, incidents, periodGroups);
+            var result = new HistoryView(
+                source.getTypeMap(),
+                map,
+                incidents,
+                periodGroups);
             result.setMomentFormatter(source.getMomentFormatter());
 
             return result;

--- a/app/src/main/java/pen/history/HistoryView.java
+++ b/app/src/main/java/pen/history/HistoryView.java
@@ -14,18 +14,22 @@ public class HistoryView
     // Constructor
 
     public HistoryView(
+        Map<String,EntityType> typeMap,
         Map<String,Entity> entityMap,
-        List<Incident> incidents, LinkedHashMap<String, List<Period>> periodGroups
+        List<Incident> incidents,
+        LinkedHashMap<String, List<Period>> periodGroups
     ) {
         this.periodGroups = periodGroups;
-        setIncidents(incidents);
+        setTypeMap(typeMap);
         setEntityMap(entityMap);
+        setIncidents(incidents);
     }
 
     /**
      * Makes a copy of the given history.
      * @param history The history
      */
+    @SuppressWarnings("unused")
     public HistoryView(History history) {
         setMomentFormatter(history.getMomentFormatter());
         setEntityMap(history.getEntityMap());
@@ -36,6 +40,11 @@ public class HistoryView
 
     //-------------------------------------------------------------------------
     // Provide unmodifiable access to data
+
+    @Override
+    public Map<String, EntityType> getTypeMap() {
+        return Collections.unmodifiableMap(typeMap());
+    }
 
     @Override
     public Map<String, Entity> getEntityMap() {

--- a/app/src/test/java/pen/history/HistoryBankTest.java
+++ b/app/src/test/java/pen/history/HistoryBankTest.java
@@ -26,7 +26,7 @@ public class HistoryBankTest extends Ted {
     @Test
     public void testAddGetEntity() {
         test("testAddGetEntity");
-        var joe = new Entity("joe", "Joe", "person");
+        var joe = new Entity("joe", "Joe", "person", true);
         history.addEntity(joe);
         check(history.getEntityMap().size()).eq(1);
         check(history.getEntity("joe").orElse(null)).eq(joe);
@@ -36,7 +36,7 @@ public class HistoryBankTest extends Ted {
     @Test
     public void testRemoveEntity() {
         test("testRemoveEntity");
-        var joe = new Entity("joe", "Joe", "person");
+        var joe = new Entity("joe", "Joe", "person", true);
         history.addEntity(joe);
         check(history.getEntityMap().isEmpty()).eq(false);
 
@@ -106,8 +106,8 @@ public class HistoryBankTest extends Ted {
     }
 
     private void populateHistory() {
-        history.addEntity(new Entity("joe", "JoeP", "person"));
-        history.addEntity(new Entity("bob", "BobC", "person"));
+        history.addEntity(new Entity("joe", "JoeP", "person", true));
+        history.addEntity(new Entity("bob", "BobC", "person", true));
         history.getIncidents()
             .add(new Incident.Start(10, "Joe is born", "joe"));
         history.getIncidents()

--- a/app/src/test/java/pen/history/HistoryQueryTest.java
+++ b/app/src/test/java/pen/history/HistoryQueryTest.java
@@ -75,7 +75,7 @@ public class HistoryQueryTest extends Ted {
         var birth = cal.date(1997, 2, 11);
         var finalDate = cal.date(2000, 3, 1);
 
-        history.addEntity(new Entity("david", "David", "person"));
+        history.addEntity(new Entity("david", "David", "person", true));
         history.getIncidents().add(new Incident.Birthday(
             cal.date2day(birth), "David's birth", Set.of("david")));
         history.getIncidents().add(new Incident.Normal(
@@ -107,7 +107,7 @@ public class HistoryQueryTest extends Ted {
             .yearLength(100)
             .build();
 
-        history.addEntity(new Entity("joe", "JoeP", "person"));
+        history.addEntity(new Entity("joe", "JoeP", "person", true));
         history.getIncidents()
             .add(new Incident.Birthday(10, "Joe is born", Set.of("joe")));
         // Ensure we have a following year
@@ -129,7 +129,7 @@ public class HistoryQueryTest extends Ted {
 
     @Test
     public void testExpandRecurring_noRecurring() {
-        history.addEntity(new Entity("joe", "JoeP", "person"));
+        history.addEntity(new Entity("joe", "JoeP", "person", true));
         history.getIncidents()
             .add(new Incident.Start(10, "Joe is born", "joe"));
 
@@ -261,8 +261,8 @@ public class HistoryQueryTest extends Ted {
     }
 
     private void populateHistory() {
-        history.addEntity(new Entity("joe", "JoeP", "person"));
-        history.addEntity(new Entity("bob", "BobC", "person"));
+        history.addEntity(new Entity("joe", "JoeP", "person", true));
+        history.addEntity(new Entity("bob", "BobC", "person", false));
         history.getIncidents()
             .add(new Incident.Start(10, "Joe is born", "joe"));
         history.getIncidents()
@@ -288,7 +288,7 @@ public class HistoryQueryTest extends Ted {
     }
 
     private void makeEntity(String id, String type, int start, int end) {
-        history.addEntity(new Entity(id, id.toUpperCase(), type));
+        history.addEntity(new Entity(id, id.toUpperCase(), type, false));
         history.getIncidents()
             .add(new Incident.Start(start, null, id));
         history.getIncidents()

--- a/examples/armorica.hist
+++ b/examples/armorica.hist
@@ -3,19 +3,19 @@
 # Dropbox/Vaults/Armorica/data.
 calendar armorican.cal cumbrian "yyyy-mm-dd"
 
-type person "Person"
-type place "Place"
+type person "Person" -prime
+type place "Place" -prime
 type war "War"
 
 entity amelie            "Amelia Fabré"       person
-entity armand            "Armand Tuppeny"     person
+entity armand            "Armand Tuppeny"     person -prime
 entity aunt-maggie       "Margaret Montjoy"   person
 entity bardot            "M. Bardot"          person
 entity dad               "Burlington Massey"  person
 entity elise             "Elise Frontenac"    person
 entity fournier          "M. Fournier"        person
 entity harte             "M. Harte"           person
-entity jack              "Jack Montjoy"       person
+entity jack              "Jack Montjoy"       person -prime
 entity jacques-le-souris "Jacques-le-Souris"  person
 entity jean-baptiste     "Jean Baptiste"      person
 entity journal           "Armand's Journal"   person ;# by courtesy

--- a/examples/armorica.hist
+++ b/examples/armorica.hist
@@ -1,5 +1,11 @@
 # History File: Letters from Armorica
+# NOTE: This is now *just* an example; the real file is in
+# Dropbox/Vaults/Armorica/data.
 calendar armorican.cal cumbrian "yyyy-mm-dd"
+
+type person "Person"
+type place "Place"
+type war "War"
 
 entity amelie            "Amelia Fabré"       person
 entity armand            "Armand Tuppeny"     person
@@ -10,7 +16,7 @@ entity elise             "Elise Frontenac"    person
 entity fournier          "M. Fournier"        person
 entity harte             "M. Harte"           person
 entity jack              "Jack Montjoy"       person
-entity jacques-le-souris "Jacques-le-Souris"   person
+entity jacques-le-souris "Jacques-le-Souris"  person
 entity jean-baptiste     "Jean Baptiste"      person
 entity journal           "Armand's Journal"   person ;# by courtesy
 entity leon              "Leon Suprenant"     person

--- a/examples/sample.hist
+++ b/examples/sample.hist
@@ -1,5 +1,6 @@
 calendar gregorian.cal gregorian "yyyy-mm-dd"
-entity joe "JoeP" person
+type person "Person" -prime
+entity joe "JoeP" person -prime
 entity bob "BobC" person
 
 birthday AD-2010-02-15 "Joe is born" joe


### PR DESCRIPTION
This pull request adds the `EntityType` class (with a prime flag) and adds a prime flag to the `Entity` class.

- The `History` classes support an entity `typeMap` of `EntityTypes` by ID.
- `HistoryExtension` requires that all entities belong to a known type.
- A history file can set the prime flag for entity types and entities.

The prime flag is not yet used for anything.