### PR TITLE
HistoryQuery simplification and HistoryTool output

### DIFF
--- a/app/src/main/java/pen/DataFiles.java
+++ b/app/src/main/java/pen/DataFiles.java
@@ -71,7 +71,6 @@ public class DataFiles {
         return new HistoryFile(
             path,
             historyExtension.getHistory(),
-            historyExtension.getQuery(),
             historyExtension.getCalendarFile().orElse(null),
             historyExtension.getPrimaryCalendar().orElse(null)
         );

--- a/app/src/main/java/pen/HistoryFile.java
+++ b/app/src/main/java/pen/HistoryFile.java
@@ -2,7 +2,6 @@ package pen;
 
 import pen.calendars.Calendar;
 import pen.history.HistoryBank;
-import pen.history.HistoryQuery;
 
 import java.nio.file.Path;
 

--- a/app/src/main/java/pen/HistoryFile.java
+++ b/app/src/main/java/pen/HistoryFile.java
@@ -10,14 +10,12 @@ import java.nio.file.Path;
  * Data loaded from a .hist file
  * @param path The file's path
  * @param history The history itself
- * @param query The default query
  * @param calendarFile The calendars associated with the history
  * @param primaryCalendar The name of the primary calendar for this history
  */
 public record HistoryFile(
     Path path,
     HistoryBank history,
-    HistoryQuery query,
     CalendarFile calendarFile,
     String primaryCalendar
 ) {

--- a/app/src/main/java/pen/apis/HistoryExtension.java
+++ b/app/src/main/java/pen/apis/HistoryExtension.java
@@ -35,9 +35,6 @@ public class HistoryExtension implements TclExtension {
     // The history
     private final HistoryBank bank = new HistoryBank();
 
-    // The default query
-    private final HistoryQuery query = new HistoryQuery();
-
     // The calendar file in use for dates, if any.
     private CalendarFile calendarFile;
 
@@ -75,9 +72,6 @@ public class HistoryExtension implements TclExtension {
         tcl.add("birthday", this::cmd_birthday);
         tcl.add("memorial", this::cmd_memorial);
         tcl.add("incident", this::cmd_incident);
-
-        var queryEnsemble = tcl.ensemble("query");
-        queryEnsemble.add("groupByPrimes", this::cmd_queryGroupByPrimes);
     }
 
     @SuppressWarnings("unused")
@@ -94,14 +88,6 @@ public class HistoryExtension implements TclExtension {
      */
     public HistoryBank getHistory() {
         return bank;
-    }
-
-    /**
-     * Gets the default query, as defined by the history script.
-     * @return The query
-     */
-    public HistoryQuery getQuery() {
-        return query;
     }
 
     /**
@@ -438,27 +424,6 @@ public class HistoryExtension implements TclExtension {
 
         var incident = new Incident.Memorial(moment, label, set);
         bank.getIncidents().add(incident);
-    }
-
-    private void cmd_queryGroupByPrimes(TclEngine tcl, Argq argq)
-        throws TclException
-    {
-        tcl.checkMinArgs(argq, 0, "?option value...?");
-        var primeEntities = new ArrayList<String>();
-        var primeTypes = new ArrayList<String>();
-
-        while (argq.hasNext()) {
-            var opt = argq.next().toString();
-
-            switch (opt) {
-                case "-entity" ->
-                    primeEntities.add(tcl.toOptArg(opt, argq).toString());
-                case "-type" ->
-                    primeTypes.add(tcl.toOptArg(opt, argq).toString());
-            }
-        }
-
-        query.groupByPrimes(primeEntities, primeTypes);
     }
 
     //-------------------------------------------------------------------------

--- a/app/src/main/java/pen/tools/annals/MainView.java
+++ b/app/src/main/java/pen/tools/annals/MainView.java
@@ -212,7 +212,7 @@ public class MainView extends VBox {
         var calendar = calFile.calendars().get(selectedCalendar);
         var date = calendar.day2date(currentDay);
 
-        var query = new HistoryQuery(histFile.query());
+        var query = new HistoryQuery();
         view = query.expandAnniversaries(selectedCalendar(), date.year())
             .execute(histFile.history());
 

--- a/app/src/main/java/pen/tools/history/HistoryTool.java
+++ b/app/src/main/java/pen/tools/history/HistoryTool.java
@@ -19,6 +19,7 @@ import pen.util.TextTable;
 
 import java.io.File;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static pen.util.TextTable.Mode.MARKDOWN;
 import static pen.util.TextTable.Mode.TERMINAL;
@@ -185,7 +186,11 @@ as follows:
         }
 
         if (options.results.contains(Result.INCIDENT)) {
-            printTable(view.getIncidents(), INCIDENTS);
+            if (options.mode == TERMINAL) {
+                printTable(view.getIncidents(), INCIDENTS);
+            } else {
+                printTable(view.getIncidents(), INCIDENTS_MARKDOWN);
+            }
         }
 
         if (options.results.contains(Result.TIMELINE)) {
@@ -288,6 +293,20 @@ as follows:
         new TextColumn<>("Concerns", TextAlign.LEFT,
             row -> String.join(", ", row.entityIds()))
     ));
+
+    public final TextTable<Incident> INCIDENTS_MARKDOWN = new TextTable<>(List.of(
+        new TextColumn<>("Moment", TextAlign.RIGHT,
+            row -> view().formatMoment(row.moment())),
+        new TextColumn<>("Incident", TextAlign.LEFT, Incident::label),
+        new TextColumn<>("Concerns", TextAlign.LEFT, this::entityLinks)
+    ));
+
+    private String entityLinks(Incident incident) {
+        return incident.entityIds().stream()
+            .map(id -> view.getEntityMap().get(id))
+            .map(this::entityLink)
+            .collect(Collectors.joining(", "));
+    }
 
     //------------------------------------------------------------------------
     // Options Structure

--- a/app/src/main/java/pen/tools/history/HistoryTool.java
+++ b/app/src/main/java/pen/tools/history/HistoryTool.java
@@ -8,6 +8,7 @@ import pen.HistoryFile;
 import pen.calendars.Calendar;
 import pen.history.History;
 import pen.history.Entity;
+import pen.history.EntityType;
 import pen.history.HistoryQuery;
 import pen.history.Incident;
 import pen.tools.FXTool;
@@ -173,13 +174,7 @@ as follows:
         }
 
         if (options.results.contains(Result.TYPE)) {
-            var types = view.getEntityMap().values().stream()
-                .map(Entity::type)
-                .distinct()
-                .sorted()
-                .collect(Collectors.joining(", "));
-
-            println("Types: " + (types.isEmpty() ? "None defined." : types));
+            printTable(getSortedTypes(), ENTITY_TYPES);
         }
 
         if (options.results.contains(Result.ENTITY)) {
@@ -240,6 +235,12 @@ as follows:
             .toList();
     }
 
+    private List<EntityType> getSortedTypes() {
+        return view.getTypeMap().values().stream()
+            .sorted(Comparator.comparing(EntityType::id))
+            .toList();
+    }
+
     private <R> void printTable(List<R> rows, TextTable<R> format) {
         println(format.toTable(rows, options.mode));
     }
@@ -263,6 +264,12 @@ as follows:
     private String entityLink(Entity e) {
         return "[[" + e.name() + "]]";
     }
+
+    public final TextTable<EntityType> ENTITY_TYPES = new TextTable<>(List.of(
+        new TextColumn<>("ID", TextAlign.LEFT, EntityType::id),
+        new TextColumn<>("Name", TextAlign.LEFT, EntityType::name),
+        new TextColumn<>("Prime", TextAlign.LEFT, t -> String.valueOf(t.prime()))
+    ));
 
     public final TextTable<Incident> INCIDENTS = new TextTable<>(List.of(
         new TextColumn<>("Moment", TextAlign.RIGHT,

--- a/app/src/main/java/pen/tools/history/HistoryTool.java
+++ b/app/src/main/java/pen/tools/history/HistoryTool.java
@@ -8,6 +8,7 @@ import pen.HistoryFile;
 import pen.calendars.Calendar;
 import pen.history.History;
 import pen.history.Entity;
+import pen.history.HistoryQuery;
 import pen.history.Incident;
 import pen.tools.FXTool;
 import pen.tools.ToolInfo;
@@ -142,7 +143,7 @@ as follows:
         var history = historyFile.history();
         var calendar = historyFile.getPrimaryCalendar();
 
-        var query = historyFile.query();
+        var query = new HistoryQuery();
 
         if (calendar != null && options.anniversaries) {
             query.expandAnniversaries(historyFile.getPrimaryCalendar());

--- a/app/src/main/java/pen/tools/history/HistoryTool.java
+++ b/app/src/main/java/pen/tools/history/HistoryTool.java
@@ -19,7 +19,6 @@ import pen.util.TextTable;
 
 import java.io.File;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static pen.util.TextTable.Mode.MARKDOWN;
 import static pen.util.TextTable.Mode.TERMINAL;

--- a/app/src/main/java/pen/tools/history/HistoryTool.java
+++ b/app/src/main/java/pen/tools/history/HistoryTool.java
@@ -229,9 +229,18 @@ as follows:
     }
 
     private List<Entity> getSortedEntities() {
-        return view.getEntityMap().values().stream()
+        var list = new ArrayList<Entity>();
+
+        view.getEntityMap().values().stream()
+            .filter(Entity::prime)
             .sorted(Comparator.comparing(Entity::id))
-            .toList();
+            .forEach(list::add);
+        view.getEntityMap().values().stream()
+            .filter(e -> !e.prime())
+            .sorted(Comparator.comparing(Entity::id))
+            .forEach(list::add);
+
+        return list;
     }
 
     private List<EntityType> getSortedTypes() {
@@ -251,13 +260,15 @@ as follows:
     public final TextTable<Entity> ENTITIES = new TextTable<>(List.of(
         new TextColumn<>("ID", TextAlign.LEFT, Entity::id),
         new TextColumn<>("Type", TextAlign.LEFT, Entity::type),
-        new TextColumn<>("Name", TextAlign.LEFT, Entity::name)
+        new TextColumn<>("Name", TextAlign.LEFT, Entity::name),
+        new TextColumn<>("Prime", TextAlign.LEFT, e -> String.valueOf(e.prime()))
     ));
 
     public final TextTable<Entity> ENTITIES_MARKDOWN = new TextTable<>(List.of(
         new TextColumn<>("ID", TextAlign.LEFT, Entity::id),
         new TextColumn<>("Type", TextAlign.LEFT, Entity::type),
-        new TextColumn<>("Name", TextAlign.LEFT, this::entityLink)
+        new TextColumn<>("Name", TextAlign.LEFT, this::entityLink),
+        new TextColumn<>("Prime", TextAlign.LEFT, e -> String.valueOf(e.prime()))
     ));
 
     private String entityLink(Entity e) {

--- a/examples/armorica.hist
+++ b/examples/armorica.hist
@@ -53,6 +53,4 @@ incident ME-1011-08-14 "Bad Times in Mont-Havre" {armand marc mont-havre madame-
 incident ME-1011-08-26 "Rumors of War"       {armand journal petit-monde jack madame-truc leon}
 memorial ME-1011-11-31 "Armand & Amelie's Wedding" {armand amelie}
 
-# Default query
-query groupByPrimes -entity armand -entity jack -type person
 


### PR DESCRIPTION
Removes the default query from the `HistoryFile`, groups by primes as the default behavior, and improves the output from HistoryTool